### PR TITLE
fix: add new blank line to ln58 on linked_list_spec file

### DIFF
--- a/spec/linked_list_spec.rb
+++ b/spec/linked_list_spec.rb
@@ -55,6 +55,7 @@ describe LinkedList do
     list.append("suu")
     list.prepend("dop")
     list.insert(1, "woo")
+    
     expect(list.to_string).to eq("dop woo plop suu")
     
     # testing edge cases:


### PR DESCRIPTION
added a line break to ln58 to apply consistent formatting for spec test files.